### PR TITLE
Added non-breaking spaces for text balance on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,12 +34,12 @@
 </head>
 <body>
     <div class="layout__container">
-        
+
     <header class="layout__header layout__main_has-hero">
-        
-    
-    
-    
+
+
+
+
     <nav class="nav-home">
         <ol>
             <li><a href="/" class="nav-home__item nav-home__item_is-active">Home</a></li>
@@ -50,11 +50,11 @@
     </nav>
 
     </header>
-        
+
     <main class="layout__main layout__main_has-hero">
         <div class="hero">
     <div class="hero__logo"></div>
-    <h1 class="hero__title">A lightweight CLI tool for visual regression testing</h1>
+    <h1 class="hero__title">A lightweight CLI tool for visual&nbsp;regression&nbsp;testing</h1>
     <pre class="hero__install"><code>$ npm install argus-eyes -g</code></pre>
 </div>
 


### PR DESCRIPTION
Around 768px, there’s room for more words on one line. But it’s better to keep the three last words together. Then the text will be easer to read/faster to scan.
